### PR TITLE
Add script to estimate transmission parameters

### DIFF
--- a/estimate_transmission_parameters.R
+++ b/estimate_transmission_parameters.R
@@ -1,0 +1,59 @@
+source("simulation_analysis_gamma_test.R")
+
+# Function to simulate a set of households
+simulate_households <- function(n_households, ...) {
+  do.call(rbind, lapply(1:n_households, function(i) sim.hh.func.fixed(N = i, ...)))
+}
+
+# Summary statistics: infection prevalence by role
+# Ensures that all roles are represented and missing roles return 0
+summary_stats <- function(df) {
+  roles <- c("infant", "sibling", "adult", "elder")
+  sapply(roles, function(r) {
+    vals <- df$infected[df$role == r]
+    if (length(vals) == 0) {
+      0
+    } else {
+      mean(vals)
+    }
+  })
+}
+
+# Generate synthetic data with known parameters
+set.seed(123)
+true_params <- c(p.comm.base.infant.fix = 0.001, p.hh.base.infant = 0.1)
+obs <- simulate_households(
+  n_households = 50,
+  p.comm.base.infant.fix = true_params[1],
+  p.hh.base.infant = true_params[2]
+)
+obs_stats <- summary_stats(obs)
+
+# Objective function to minimize
+objective <- function(par) {
+  sim <- simulate_households(
+    n_households = 50,
+    p.comm.base.infant.fix = par[1],
+    p.hh.base.infant = par[2]
+  )
+  sim_stats <- summary_stats(sim)
+  if (any(is.na(sim_stats))) {
+    return(Inf)
+  }
+  sum((sim_stats - obs_stats)^2)
+}
+
+# Initial guess and parameter bounds
+init <- c(0.005, 0.2)
+fit <- optim(
+  par = init,
+  fn = objective,
+  method = "L-BFGS-B",
+  lower = c(0, 0),
+  upper = c(1, 1)
+)
+
+cat("True parameters:\n")
+print(true_params)
+cat("\nEstimated parameters:\n")
+print(fit$par)


### PR DESCRIPTION
## Summary
- add `estimate_transmission_parameters.R` with example optimization to recover transmission probabilities from simulated data
- guard optimization against missing roles and `NA` statistics

## Testing
- `Rscript estimate_transmission_parameters.R` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*
- `apt-get install -y r-base` *(fails: unable to locate package r-base)*

------
https://chatgpt.com/codex/tasks/task_e_6893a2baf5c08327b3339a5acf455c3b