### PR TITLE
Implement delay-based infection imputation and parameter averaging

### DIFF
--- a/estimate parameters
+++ b/estimate parameters
@@ -1,18 +1,47 @@
 
-## ---------------------------------------------------------------------------
-## 2.  Define a common study calendar                                         ##
-## ---------------------------------------------------------------------------
+###############################################################################
+## 1.  Load raw synthetic data and summarise per individual                  ##
+###############################################################################
+library(data.table)
+library(ggplot2)
+
+source("generate_synthetic_data.R")
+
+set.seed(123)
+raw_dt <- sim.hh.func.fixed(N = 100)
+dt <- as.data.table(raw_dt)
+
+dt <- dt[, .(
+  first.infection.detected.start = if (any(infection_status == 1))
+      min(test_date[infection_status == 1]) else NA_integer_,
+  first.infection.detected.end   = if (any(infection_status == 1))
+      max(test_date[infection_status == 1]) else NA_integer_,
+  last_negative                  = if (any(infection_status == 0 &
+                                           test_date < min(test_date[infection_status == 1])))
+      max(test_date[infection_status == 0 &
+                    test_date < min(test_date[infection_status == 1])]) else NA_integer_,
+  first.infection.infectious.day = if (any(infection_status == 1))
+      paste(test_date[infection_status == 1], collapse = ",") else NA_character_,
+  role = role[1]
+), by = .(HH, individual_ID)]
+
+setnames(dt, "individual_ID", "indiv.index")
+
+###############################################################################
+## 2.  Define a common study calendar                                        ##
+###############################################################################
 study_start <- as.Date("2024-09-21")            # same as before
-study_end <- as.Date("2025-04-17") 
-#   If your relative days (134 … 152) are counted from *day 0 = study_start*
+study_end   <- as.Date("2025-04-17")
+#   If your relative days are counted from *day 0 = study_start*
 #   you can convert them directly:
 conv <- function(x) fifelse(is.na(x), as.Date(NA), study_start + as.integer(x))
 
-dt[, T_FP_date  := conv(first.infection.detected.start)]   # first pos PCR
-dt[, T_LP_date  := conv(first.infection.detected.end)]     # last  pos PCR
-dt[, inf_date   := conv(first.infection.true.date)]        # true infection
-dt[, inf_start_date := T_FP_date]                          # will refine
-dt[, inf_end_date   := T_LP_date]                          
+dt[, T_FP_date    := conv(first.infection.detected.start)]   # first pos PCR
+dt[, T_LP_date    := conv(first.infection.detected.end)]     # last  pos PCR
+dt[, last_neg_date:= conv(last_negative)]
+dt[, inf_date     := as.Date(NA)]                            # to be imputed
+dt[, inf_start_date := T_FP_date]                            # will refine
+dt[, inf_end_date   := T_LP_date]
 
 ## – If your relative days use *another* origin, adjust `study_start`
 ##   or subtract the correct offset before calling `conv()`.
@@ -137,36 +166,46 @@ negll <- function(par, dat, lambda = 0.01, eps = 1e-10){
 }
 
 ###############################################################################
-## 7.  Multiple‑imputation + ML
+## 7.  Repeated imputation + ML
 ###############################################################################
-M <- 20                                       # imputations
-theta_mat <- matrix(NA_real_, M, 9)
-vcov_list <- vector("list", M)
+N <- 30                                       # number of repetitions
+theta_mat <- matrix(NA_real_, N, 9)
+vcov_list <- vector("list", N)
 tmax = -as.integer(as.Date("2024-09-21") - as.Date("2025-04-17"))
 cases_t <- pmax(0, round(30*sin(2*pi*(0:tmax)/365) + rnorm(tmax+1, 0, 5)))
 
 start_par <- c(-6, 0.02, -2, rep(0, 6))       # length 9
 
-for (m in 1:M){
+for (m in 1:N){
   imp <- copy(dt)
   
   ## --- draw delays for infected individuals ---------------------------
   idx <- which(imp$infected)
   if (length(idx)){
-    max_back <- ifelse(is.na(imp$first.infection.true.duration[idx]),
-                       14,                              # fallback window
-                       imp$first.infection.true.duration[idx]) # if given
-    lat <- rtrunc_gamma(length(idx), 2, 1, max_back)
-    repd<- rtrunc_gamma(length(idx), 1, 1.5, pmax(max_back-lat,1e-8))
-    infd<- rgamma(length(idx), 3, rate=1/2)
-    
-    imp$inf_date[idx]       <- imp$T_FP_date[idx] - (lat + repd)
-    imp$inf_start_date[idx] <- imp$inf_date[idx]  + lat
-    imp$inf_end_date[idx]   <- imp$inf_start_date[idx] + infd
-    
-    imp$inf_day_rl[idx]            <- as.integer(imp$inf_date[idx]-study_start)
-    imp$infectious_day_rl[idx]     <- as.integer(imp$inf_start_date[idx]-study_start)
-    imp$infectious_end_day_rl[idx] <- as.integer(imp$inf_end_date[idx]-study_start)
+    max_back <- ifelse(is.na(imp$last_neg_date[idx]),
+                       14,
+                       as.integer(imp$T_FP_date[idx] - imp$last_neg_date[idx]))
+    lat  <- rtrunc_gamma(length(idx), latent_par$shape, latent_par$scale, max_back)
+    repd <- rtrunc_gamma(length(idx), report_par$shape, report_par$scale,
+                         pmax(max_back - lat, 1e-8))
+    infd <- rgamma(length(idx), infect_par$shape, rate = 1/infect_par$scale)
+
+    imp$latent_delay[idx]   <- lat
+    imp$report_delay[idx]   <- repd
+    imp$infect_period[idx]  <- infd
+
+    imp$inf_date[idx] <- imp$T_FP_date[idx] - (lat + repd)
+    has_neg <- !is.na(imp$last_neg_date[idx])
+    imp$inf_date[idx][has_neg] <- pmax(imp$inf_date[idx][has_neg],
+                                       imp$last_neg_date[idx][has_neg] + 1)
+
+    imp$inf_start_date[idx] <- imp$inf_date[idx] + lat
+    imp$inf_end_date[idx]   <- pmin(imp$inf_start_date[idx] + infd,
+                                    imp$T_LP_date[idx])
+
+    imp$inf_day_rl[idx]            <- as.integer(imp$inf_date[idx]       - study_start)
+    imp$infectious_day_rl[idx]     <- as.integer(imp$inf_start_date[idx] - study_start)
+    imp$infectious_end_day_rl[idx] <- as.integer(imp$inf_end_date[idx]   - study_start)
   }
   
   ## --- build person‑day table -----------------------------------------
@@ -211,7 +250,7 @@ for (m in 1:M){
 keep <- complete.cases(theta_mat[,1])
 theta_mat <- theta_mat[keep,,drop = FALSE]
 
-mean_est <- colMeans(theta_mat)           # average across imputations
+mean_est <- colMeans(theta_mat)           # average across runs
 
 par_names <- c("delta0","delta1","alpha0",
                "gamma2","gamma3","gamma4",
@@ -238,7 +277,7 @@ result <- data.table(
   Estimate  = round(mean_est, 3),
   Bias      = round(mean_est - true_vec, 3))
 
-cat("\n*** Mean of", nrow(theta_mat), "imputations (no Rubin pooling) ***\n")
+cat("\n*** Mean of", nrow(theta_mat), "runs (no Rubin pooling) ***\n")
 print(result)
 
 ###############################################################################


### PR DESCRIPTION
## Summary
- Generate synthetic households directly and summarise individuals
- Impute infection timing using truncated delay distributions bounded by last negative and last positive tests
- Repeat likelihood estimation across multiple runs and report mean parameters

## Testing
- `apt-get update` *(fails: repository not signed)*
- `R -q -e 'cat("test")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e8a880d48327ab4c88d8802737f0